### PR TITLE
Fixed the python file so it wouldn't fail on startup

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY requirements.txt .
 
+RUN apt-get update && apt-get install -y sqlite3  
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/api/db/database.py
+++ b/api/db/database.py
@@ -1,7 +1,7 @@
 """Used to hold the information about the database and commands used with it"""
 
 import sqlite3
-from objects import User
+from db.objects import User
 
 class Database_Connection():
     """Used as a singleton to access the database"""
@@ -14,13 +14,13 @@ class Database_Connection():
     
     def __init__(self):
         """Handles initializing the class"""
-        self.conn = sqlite3.connect('cookbook.db')
+        self.conn = sqlite3.connect('db/cookbook.db')
         self.cursor = self.conn.cursor()
 
         # Checking if the tables exist
-        userTable = self.cursor.execute("SELECT tableName FROM sqlite_master WHERE type='table' AND tableName='Users'").fetchone()
+        userTable = self.cursor.execute("SELECT tbl_name FROM sqlite_master WHERE type='table' AND tbl_name='Users'").fetchone()
         if userTable is None:
-            with open("my_script.sql", "r") as sql_file:
+            with open("db/createUserTable.sql", "r") as sql_file:
                 sql_script = sql_file.read()
                 self.cursor.executescript(sql_script)
                 self.conn.commit()


### PR DESCRIPTION
To fix this file, I changed the sqlite command to use tbl_name rather than tableName, since tableName doesn't exist as a column. Change the db file to use the cookbook db in the dob folder, rather than the one in the api folder. Added sqlite to the python container.